### PR TITLE
fix: 다음 차수 포지션의 진입가격이 중간 가격을 건너뛰던 점 수정

### DIFF
--- a/trading/bot.py
+++ b/trading/bot.py
@@ -22,7 +22,8 @@ class TradingBot:
                 current_price = pyupbit.get_current_price(TICKER)
 
                 if self.check_buy(current_price):
-                    await self.open_position(current_price, BUY_QUANTITY)
+                    last_price = self.position_manager.get_last_position().entry_price
+                    await self.open_position(last_price-STEP, BUY_QUANTITY)
 
                 if self.check_sell(current_price):
                     target_position = self.position_manager.get_position_by_target_price(current_price)


### PR DESCRIPTION
예를 들어 1500원에 1차 진입을 했는데 오더북상 변동으로 1499원에 2차 매수가 들어가는게 아니라
1498원 1497원 등에 진입하던 점 수정